### PR TITLE
Replace character that stops the plugin styles from working in popout windows

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -271,7 +271,7 @@ body {
 		& div.cm-scroller {
 			overflow: visible;
 
-			.ͼ1 & {
+			.cm-editor & {
 				font-family: var(--font-text);
 				line-height: var(--line-height-normal);
 			}


### PR DESCRIPTION
This `ͼ` character, used by CodeMirror, for some reason stops Obsidian from adding the plugin's styles to new popout windows.

[According to CodeMirror](https://discuss.codemirror.net/t/why-does-cm6-use-the-character-in-class-names/2821/2) these classes shouldn't even be used since they're generated and not stable.
I've replaced it with `.cm-editor` which also only appears on the same element as the previous selector.

Here's another forum post of a user hitting the same problem with that character, but unrelated to this plugin: https://forum.obsidian.md/t/evil-jank-regarding-the-specific-text-1/67227

A temporary workaround for users experiencing this problem until this fix is merged, is to create an Obsidian CSS snippet with the contents of [styles.css](https://github.com/unxok/obsidian-better-properties/blob/main/styles.css) and the problematic character replaced, as shown in this PR.